### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides SSH access to remote servers, allowing AI tools like Claude Desktop or VS Code to securely connect to your VPS for website management.
 
+<a href="https://glama.ai/mcp/servers/@mixelpixx/SSH-MCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mixelpixx/SSH-MCP/badge" alt="SSH MCP server" />
+</a>
+
 ## Features
 
 - SSH connection management with password or key-based authentication


### PR DESCRIPTION
This PR adds a badge for the [SSH MCP](https://glama.ai/mcp/servers/@mixelpixx/SSH-MCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mixelpixx/SSH-MCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mixelpixx/SSH-MCP/badge" alt="SSH MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.