### PR TITLE
fix: prevent stdout logging from breaking MCP stdio transport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import * as dotenv from "dotenv";
 import { addUbuntuTools, ubuntuToolHandlers } from "./ubuntu-website-tools.js";
 
 // Load environment variables from .env file if present
-dotenv.config();
+dotenv.config({ quiet: true });
 
 class SSHMCPServer {
   private server: Server;

--- a/src/ubuntu-website-tools.ts
+++ b/src/ubuntu-website-tools.ts
@@ -779,5 +779,5 @@ export function addUbuntuTools(server: Server, connections: Map<string, { conn: 
     };
   });
   
-  console.log("Ubuntu website management tools loaded");
+  console.error("Ubuntu website management tools loaded");
 }


### PR DESCRIPTION
## Summary
Prevents two sources of stdout pollution that corrupt the MCP stdio JSON-RPC transport.

## Changes
1. **`src/index.ts`**: Pass `{ quiet: true }` to `dotenv.config()` — dotenv v17+ logs injected env vars to stdout by default, which breaks the MCP protocol stream
2. **`src/ubuntu-website-tools.ts`**: Change `console.log` → `console.error` for the "Ubuntu website management tools loaded" message

## Why This Matters
MCP stdio transport uses stdout exclusively for JSON-RPC messages. Any `console.log` output corrupts the protocol stream, causing Claude Desktop to log:
```
MCP ssh-server: Unexpected token 'U', "Ubuntu web"... is not valid JSON
```

## Testing
1. Install dotenv v17+ and configure a `.env` file
2. Start the MCP server via stdio transport
3. Verify no stdout pollution before JSON-RPC messages
4. Connect from Claude Desktop and confirm clean initialization

## Related Issues
Fixes #5
Fixes #4